### PR TITLE
Correct issue with extracting wire on windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ Thumbs.db
 
 # Maven #
 #########
-*/target/*
+**/target/*
 
 # Other IDE's#
 ##############

--- a/src/main/java/com/lazerycode/selenium/extract/FileExtractor.java
+++ b/src/main/java/com/lazerycode/selenium/extract/FileExtractor.java
@@ -74,17 +74,16 @@ public class FileExtractor {
      * @throws IOException
      */
 
-    protected String unzipFile(File downloadedCompressedFile, String extractedToFilePath, BinaryType possibleFilenames) throws IOException, ExpectedFileNotFoundException {
+    protected String unzipFile(File downloadedCompressedFile, String extractedToFilePath, BinaryType type) throws IOException, ExpectedFileNotFoundException {
         LOG.debug("Attempting to extract binary from .zip file...");
-        ArrayList<String> filenamesWeAreSearchingFor = possibleFilenames.getBinaryFilenames();
-        String driverName = possibleFilenames.getDriverSystemProperty();
+        ArrayList<String> filenamesWeAreSearchingFor = type.getBinaryFilenames();
         ZipFile zip = new ZipFile(downloadedCompressedFile);
         try {
             Enumeration<ZipArchiveEntry> zipFile = zip.getEntries();
             while (zipFile.hasMoreElements()) {
                 ZipArchiveEntry zipFileEntry = zipFile.nextElement();
                 for (String aFilenameWeAreSearchingFor : filenamesWeAreSearchingFor) {
-                    if (driverName.equals("webdriver.gecko.driver") &&
+                    if (type.equals(BinaryType.MARIONETTE) &&
                       zipFileEntry.getName().matches(aFilenameWeAreSearchingFor)) {
                         LOG.debug("Found: " + zipFileEntry.getName());
                         return copyFileToDisk(zip.getInputStream(zipFileEntry), extractedToFilePath, zipFileEntry.getName());
@@ -99,7 +98,7 @@ public class FileExtractor {
             zip.close();
         }
 
-        throw new ExpectedFileNotFoundException("Unable to find any expected files for " + possibleFilenames.getBinaryTypeAsString());
+        throw new ExpectedFileNotFoundException("Unable to find any expected files for " + type.getBinaryTypeAsString());
     }
 
     /**

--- a/src/main/java/com/lazerycode/selenium/extract/FileExtractor.java
+++ b/src/main/java/com/lazerycode/selenium/extract/FileExtractor.java
@@ -77,12 +77,18 @@ public class FileExtractor {
     protected String unzipFile(File downloadedCompressedFile, String extractedToFilePath, BinaryType possibleFilenames) throws IOException, ExpectedFileNotFoundException {
         LOG.debug("Attempting to extract binary from .zip file...");
         ArrayList<String> filenamesWeAreSearchingFor = possibleFilenames.getBinaryFilenames();
+        String driverName = possibleFilenames.getDriverSystemProperty();
         ZipFile zip = new ZipFile(downloadedCompressedFile);
         try {
             Enumeration<ZipArchiveEntry> zipFile = zip.getEntries();
             while (zipFile.hasMoreElements()) {
                 ZipArchiveEntry zipFileEntry = zipFile.nextElement();
                 for (String aFilenameWeAreSearchingFor : filenamesWeAreSearchingFor) {
+                    if (driverName.equals("webdriver.gecko.driver") &&
+                      zipFileEntry.getName().matches(aFilenameWeAreSearchingFor)) {
+                        LOG.debug("Found: " + zipFileEntry.getName());
+                        return copyFileToDisk(zip.getInputStream(zipFileEntry), extractedToFilePath, zipFileEntry.getName());
+                    }
                     if (zipFileEntry.getName().endsWith(aFilenameWeAreSearchingFor)) {
                         LOG.debug("Found: " + zipFileEntry.getName());
                         return copyFileToDisk(zip.getInputStream(zipFileEntry), extractedToFilePath, aFilenameWeAreSearchingFor);

--- a/src/main/java/com/lazerycode/selenium/repository/BinaryType.java
+++ b/src/main/java/com/lazerycode/selenium/repository/BinaryType.java
@@ -28,7 +28,7 @@ public enum BinaryType {
             "webdriver.opera.driver"),
     MARIONETTE(
             new ArrayList<String>() {{
-                add("wires.*");
+                add("wires-\\d\\.\\d\\.\\d-.+(\\.exe)?");
             }},
             "webdriver.gecko.driver");
 

--- a/src/test/java/com/lazerycode/selenium/repository/BinaryTypeTest.java
+++ b/src/test/java/com/lazerycode/selenium/repository/BinaryTypeTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 
 import static com.lazerycode.selenium.repository.BinaryType.GOOGLECHROME;
+import static com.lazerycode.selenium.repository.BinaryType.MARIONETTE;
 import static com.lazerycode.selenium.repository.BinaryType.PHANTOMJS;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -34,5 +35,23 @@ public class BinaryTypeTest {
     public void willReturnCorrectSystemPropertyForABinary() {
         assertThat(GOOGLECHROME.getDriverSystemProperty(),
                 is(equalTo("webdriver.chrome.driver")));
+    }
+
+    @Test
+    public void testWiresRegexWindows() {
+        String wireBinary = "wires-0.0.0-win.exe";
+        ArrayList<String> matchers = MARIONETTE.getBinaryFilenames();
+        for(String matcher : matchers) {
+            assertThat(wireBinary.matches(matcher), is(true));
+        }
+    }
+
+    @Test
+    public void testWiresRegexNix() {
+        String wireBinary = "wires-0.0.0-OSX";
+        ArrayList<String> matchers = MARIONETTE.getBinaryFilenames();
+        for(String matcher : matchers) {
+            assertThat(wireBinary.matches(matcher), is(true));
+        }
     }
 }


### PR DESCRIPTION
These changes will allow extraction of the wire executable when run on windows. The old code was trying to use a regular expression with String.endsWith() which doesn't support regular expressions. Instead we should be using String.matches() and use a more robust regular expression to match on. Since only the MARIONETTE driver requires the use of a regular expression we check for the driver type and if it is MARIONETTE we use matches, otherwise we still use endsWith. Note that wire archive is only in zip format on windows thus only the unzipFile was modified. I Added some test cases to check the regular expression. I tested this on windows and osx and seems to be working. 