### PR TITLE
#38 Add in support for Edge Driver -- use correct id

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ ___Below is an example RepositoryMap.xml that I will endeavour to keep up to dat
                     </bitrate>
                 </version>
             </driver>
-            <driver id="edgedriver">
+            <driver id="edge">
                 <version id="3.14393">
                     <bitrate sixtyfourbit="true" thirtytwobit="true">
                         <filelocation>https://download.microsoft.com/download/3/2/D/32D3E464-F2EF-490F-841B-05D53C848D15/MicrosoftWebDriver.exe</filelocation>

--- a/src/main/resources/RepositoryMap.xml
+++ b/src/main/resources/RepositoryMap.xml
@@ -15,7 +15,7 @@
                 </bitrate>
             </version>
         </driver>
-        <driver id="edgedriver">
+        <driver id="edge">
             <version id="3.14393">
                 <bitrate sixtyfourbit="true" thirtytwobit="true">
                     <filelocation>https://download.microsoft.com/download/3/2/D/32D3E464-F2EF-490F-841B-05D53C848D15/MicrosoftWebDriver.exe</filelocation>


### PR DESCRIPTION
Using the default settings the plugin fails  on windows. 

```
[ERROR] Failed to execute goal com.lazerycode.selenium:driver-binary-downloader-
maven-plugin:1.0.11:selenium (default) on project cucumber: Execution default of
goal com.lazerycode.selenium:driver-binary-downloader-maven-plugin:1.0.11:selen
ium failed: No enum constant com.lazerycode.selenium.repository.BinaryType.EDGED
RIVER -> [Help 1]
```

driver id should be "edge" rather then "edgedriver" in RepositoryMap.xml 