### PR TITLE
Fixes #47 - Adds ability to read repository map from dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
             <version>1.16.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-resources</artifactId>
+            <version>1.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
You're now able to have something like this:

```
<plugin>
	<groupId>com.lazerycode.selenium</groupId>
	<artifactId>driver-binary-downloader-maven-plugin</artifactId>
	<version>${lazerycode.selenium.version}</version>
	<configuration>
		<rootStandaloneServerDirectory>${browser.location}</rootStandaloneServerDirectory>
		<downloadedZipFileDirectory>${browser.location}/zips</downloadedZipFileDirectory>
		<customRepositoryMap>/config/RepositoryMap.xml</customRepositoryMap>
		<onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
		<throwExceptionIfSpecifiedVersionIsNotFound>true</throwExceptionIfSpecifiedVersionIsNotFound>
		<fileDownloadRetryAttempts>3</fileDownloadRetryAttempts>
		<fileDownloadConnectTimeout>20000</fileDownloadConnectTimeout>
		<fileDownloadReadTimeout>20000</fileDownloadReadTimeout>
		<checkFileHashes>true</checkFileHashes>
	</configuration>
	<dependencies>
		<dependency>
			<groupId>com.mycompany.gauge</groupId>
			<artifactId>mycompany-buildtools</artifactId>
			<version>1.0</version>
		</dependency>
	</dependencies>
	<executions>
		<execution>
			<goals>
				<goal>selenium</goal>
			</goals>
		</execution>
	</executions>
</plugin>
```
