### PR TITLE
Download files when hash does not match

### DIFF
--- a/src/main/java/com/lazerycode/selenium/download/DownloadHandler.java
+++ b/src/main/java/com/lazerycode/selenium/download/DownloadHandler.java
@@ -113,7 +113,7 @@ public class DownloadHandler {
                 if (checkFileHash(localZipFile, driverDetails.hash, driverDetails.hashType)) {
                     fileNeedsToBeDownloaded = false;
                 } else {
-                    fileNeedsToBeDownloaded = false;
+                    fileNeedsToBeDownloaded = true;
                 }
             }
         }


### PR DESCRIPTION
Looks like a small bug in the code, even when hashing did not match the code did not attempt to re-download.