### PR TITLE
Add explicit dependency on JaxB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,24 @@
     </properties>
 
     <dependencies>
+        <!--JaxB-->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+        <!--Maven -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
@@ -105,6 +123,8 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.4</version>
         </dependency>
+
+        <!--Misc -->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -191,7 +211,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.5</version>
                 <configuration>
                     <!-- TODO: workaround for  http://jira.codehaus.org/browse/MNG-5346 -->
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/src/main/java/com/lazerycode/selenium/extract/FileExtractor.java
+++ b/src/main/java/com/lazerycode/selenium/extract/FileExtractor.java
@@ -16,8 +16,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 
 import static com.lazerycode.selenium.extract.DownloadableFileType.TAR;
 
@@ -81,7 +81,7 @@ public class FileExtractor {
 
     String unzipFile(File downloadedCompressedFile, String extractedToFilePath, BinaryType possibleFilenames) throws IOException, ExpectedFileNotFoundException {
         LOG.debug("Attempting to extract binary from .zip file...");
-        ArrayList<String> filenamesWeAreSearchingFor = possibleFilenames.getBinaryFilenames();
+        List<String> filenamesWeAreSearchingFor = possibleFilenames.getBinaryFilenames();
         ZipFile zip = new ZipFile(downloadedCompressedFile);
         try {
             Enumeration<ZipArchiveEntry> zipFile = zip.getEntries();
@@ -114,7 +114,7 @@ public class FileExtractor {
     private String untarFile(InputStream compressedFileInputStream, String extractedToFilePath, BinaryType possibleFilenames) throws IOException, ExpectedFileNotFoundException {
         LOG.debug("Attempting to extract binary from a .tar file...");
         ArchiveEntry currentFile;
-        ArrayList<String> filenamesWeAreSearchingFor = possibleFilenames.getBinaryFilenames();
+        List<String> filenamesWeAreSearchingFor = possibleFilenames.getBinaryFilenames();
         ArchiveInputStream archiveInputStream = new TarArchiveInputStream(compressedFileInputStream);
         try {
             while ((currentFile = archiveInputStream.getNextEntry()) != null) {

--- a/src/main/java/com/lazerycode/selenium/repository/BinaryType.java
+++ b/src/main/java/com/lazerycode/selenium/repository/BinaryType.java
@@ -1,54 +1,56 @@
 package com.lazerycode.selenium.repository;
 
-import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
 
 public enum BinaryType {
     INTERNETEXPLORER(
-            new ArrayList<String>() {{
-                add("IEDriverServer.exe");
-            }},
+            asList(
+                    "IEDriverServer.exe"
+            ),
             "webdriver.ie.driver"),
     GOOGLECHROME(
-            new ArrayList<String>() {{
-                add("chromedriver.exe");
-                add("chromedriver");
-            }},
+            asList(
+                    "chromedriver.exe",
+                    "chromedriver"
+            ),
             "webdriver.chrome.driver"),
     PHANTOMJS(
-            new ArrayList<String>() {{
-                add("phantomjs.exe");
-                add("phantomjs");
-            }},
+            asList(
+                    "phantomjs.exe",
+                    "phantomjs"
+            ),
             "phantomjs.binary.path"),
     OPERACHROMIUM(
-            new ArrayList<String>() {{
-                add("operadriver.exe");
-                add("operadriver");
-            }},
+            asList(
+                    "operadriver.exe",
+                    "operadriver"
+            ),
             "webdriver.opera.driver"),
     MARIONETTE(
-            new ArrayList<String>() {{
-                add("wires");
-                add("wires.exe");
-                add("geckodriver");
-                add("geckodriver.exe");
-            }},
+            asList(
+                    "wires",
+                    "wires.exe",
+                    "geckodriver",
+                    "geckodriver.exe"
+            ),
             "webdriver.gecko.driver"),
     EDGE(
-            new ArrayList<String>() {{
-                add("MicrosoftWebDriver.exe");
-            }},
+            asList(
+                    "MicrosoftWebDriver.exe"
+            ),
             "webdriver.edge.driver");
 
-    private final ArrayList<String> binaryFilenames;
+    private final List<String> binaryFilenames;
     private final String driverSystemProperty;
 
-    BinaryType(ArrayList<String> binaryFilenames, String driverSystemProperty) {
+    BinaryType(List<String> binaryFilenames, String driverSystemProperty) {
         this.binaryFilenames = binaryFilenames;
         this.driverSystemProperty = driverSystemProperty;
     }
 
-    public ArrayList<String> getBinaryFilenames() {
+    public List<String> getBinaryFilenames() {
         return binaryFilenames;
     }
 

--- a/src/test/java/com/lazerycode/selenium/repository/BinaryTypeTest.java
+++ b/src/test/java/com/lazerycode/selenium/repository/BinaryTypeTest.java
@@ -2,7 +2,7 @@ package com.lazerycode.selenium.repository;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import static com.lazerycode.selenium.repository.BinaryType.GOOGLECHROME;
 import static com.lazerycode.selenium.repository.BinaryType.PHANTOMJS;
@@ -14,7 +14,7 @@ public class BinaryTypeTest {
 
     @Test
     public void willReturnAListOfFilenameAssociatedWithBinary() {
-        ArrayList<String> binaryFilenames = PHANTOMJS.getBinaryFilenames();
+        List<String> binaryFilenames = PHANTOMJS.getBinaryFilenames();
 
         assertThat(binaryFilenames.size(),
                 is(equalTo(2)));


### PR DESCRIPTION
Java 9 added the Jigsaw module system and moved `java.xml.bind` into
a module. This module is not active by default. It can be be activated
by running with `--add-modules java.xml.bind` however as it is scheduled
to be removed in Java 10 it is prudent to migrate away from it now.

As such the `jaxb-api`, glassfishes `jaxb-runtime` reference
implementation and its dependency `javax.activation` have been added as
maven dependencies.

Additionally the `maven-plugin-plugin` failed to execute the help goal.
This appeared to be caused by the initializer blocks of the anonymous
subclass of the array list in BinaryType.

This has been resolved by incrementing the plugin version and using
`Arrays.asList` and replacing the use of `ArrayList` with the more
general `List` interface where necessary.