### PR TITLE
Added "aarch64" for M1 Monterey

### DIFF
--- a/src/main/java/com/lazerycode/selenium/repository/SystemArchitecture.java
+++ b/src/main/java/com/lazerycode/selenium/repository/SystemArchitecture.java
@@ -21,7 +21,7 @@ public enum SystemArchitecture {
 
     public static final SystemArchitecture defaultSystemArchitecture = ARCHITECTURE_32_BIT;
     private static List<String> architecture64bitNames = Arrays.asList("amd64", "x86_64");
-    private static List<String> architectureArmNames = Arrays.asList("arm", "armv41");
+    private static List<String> architectureArmNames = Arrays.asList("arm", "armv41", "aarch64");
 
     public static SystemArchitecture getSystemArchitecture(String currentArchitecture) {
         SystemArchitecture result = defaultSystemArchitecture;


### PR DESCRIPTION
Added "aarch64", this is needed on M1 mac's running Mac OS Monterey